### PR TITLE
Implemented Chinese parsing.

### DIFF
--- a/modua/modua_app/test_utils.py
+++ b/modua/modua_app/test_utils.py
@@ -1,5 +1,5 @@
 from django.test import SimpleTestCase
-from .utils import segmentize, is_delimited
+from .utils import segmentize, is_delimited, all_combinations
 
 
 class TestUtils(SimpleTestCase):
@@ -20,3 +20,7 @@ class TestUtils(SimpleTestCase):
         '''Test that the is_delimited function works'''
         self.assertTrue(is_delimited('en-US'))
         self.assertFalse(is_delimited('zh-Hanz'))
+
+    def test_all_combinations(self):
+        result = all_combinations('abc')
+        self.assertTrue(result == {'abc', 'ab', 'bc', 'a','b', 'c'})

--- a/modua/modua_app/urls.py
+++ b/modua/modua_app/urls.py
@@ -5,7 +5,7 @@ from . import views
 
 
 urlpatterns = [
-    url(r'^languages/(?P<language>[\w-]+)/(?P<word>[\w-]+)', views.DefinitionGenericView.as_view(), name='definition-generic'),
+    url(r'^languages/(?P<language>[\w-]+)/(?P<word>[\w-]+)', views.DefinitionListView.as_view(), name='definition-word-list'),
     url(r'^languages/(?P<language>[\w-]+)/', views.DefinitionListView.as_view(), name='definition-list'),
     url(r'^languages/', views.LanguageListView.as_view(), name='language-list'),
     url(r'^$', views.api_root, name='api-root'),

--- a/modua/modua_app/utils.py
+++ b/modua/modua_app/utils.py
@@ -2,6 +2,7 @@
 '''A utility package for MODUA'''
 import re
 
+
 def segmentize(string):
     '''Yields a generator of string in segmented form.
 
@@ -16,6 +17,15 @@ def segmentize(string):
         yield lexeme
 
 
+def all_combinations(string):
+    """Yields all possible combinations of substrings."""
+    s = set()
+    for i in range(len(string)):
+        for seg in segmentize(string[i:]):
+            s.add(seg)
+    return s
+
+
 def is_delimited(tag):
     '''Returns True if the language tag identifies a space delimited
     language, otherwise returns False'''
@@ -27,3 +37,7 @@ def is_delimited(tag):
         return True
     if subtags[0] == 'zh':
         return False
+
+if __name__ == '__main__':
+    result = all_combinations('abc')
+    assert result == {'abc', 'ab', 'bc', 'a','b', 'c'}

--- a/modua/modua_app/utils.py
+++ b/modua/modua_app/utils.py
@@ -18,7 +18,7 @@ def segmentize(string):
 
 
 def all_combinations(string):
-    """Yields all possible combinations of substrings."""
+    """Returns a set of yields all possible combinations of substrings."""
     s = set()
     for i in range(len(string)):
         for seg in segmentize(string[i:]):
@@ -37,7 +37,3 @@ def is_delimited(tag):
         return True
     if subtags[0] == 'zh':
         return False
-
-if __name__ == '__main__':
-    result = all_combinations('abc')
-    assert result == {'abc', 'ab', 'bc', 'a','b', 'c'}


### PR DESCRIPTION
A request for definitions from an arbitrary string of Chinese characters, such as "反射作用", will return a JSON of the definitions for the full string ("反射作用"), the individual characters ("反", "射", "作"," 用"), and any other substrings ("反射", "作用"), provided that these match entries in the DB.

I don't think this is an ideal default implementation (should maybe instead be the result of a query with an "all" argument or something), but will allow us to start working with the front-end even with just arbitrary Chinese strings.